### PR TITLE
Updated passport-oauth2 version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "./lib/passport-youtube-v3",
   "dependencies": {
-    "passport-oauth2": "1.1.2"
+    "passport-oauth2": "1.4.0"
   },
   "readme": "passport-youtube-v3\n================\n\nYoutube API v3 strategy for passport",
   "devDependencies": {


### PR DESCRIPTION
Since passport-oauth2@1.1.2 used arguments.callee in one instance it could not be used with ES6 and therefore newer versions of node. passport-oauth2@1.4.0 uses this.constructor to solve this issue.